### PR TITLE
Gael modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ cd gekko
 ### 📖 Detailed Guide
 Check out our comprehensive [Installation Guide for Ubuntu](INSTALLATION_GUIDE.md) - a step-by-step tutorial that covers everything from installing Node.js to running your first backtest!
 
+### 🔧 Node.js v22 Compatibility
+Using Node.js v22+? See our [Node.js v22 Compatibility Guide](docs/installation/nodejs-v22-compatibility.md) for updated installation instructions and troubleshooting tips.
+
 ## Built On
 
 - **Node.js 22+** - JavaScript runtime environment (LTS and Current versions supported)

--- a/docs/installation/nodejs-v22-compatibility.md
+++ b/docs/installation/nodejs-v22-compatibility.md
@@ -1,0 +1,147 @@
+# Node.js v22 Compatibility Guide
+
+This guide covers the compatibility improvements made to Gekko for Node.js v22+ (LTS and Current versions).
+
+## Overview
+
+Gekko has been updated to fully support Node.js v22.16.0 and later versions. Several key changes were made to ensure compatibility with the latest Node.js runtime.
+
+## Key Changes Made
+
+### 1. Koa Framework Downgrade
+
+**Issue**: Koa v3.0.0+ dropped support for generator functions, which are used throughout Gekko's middleware.
+
+**Solution**: 
+- Downgraded Koa from v3.0.0 to v2.16.1
+- Downgraded koa-router from v13+ to v12.0.1
+- Added koa-convert v2.0.0 to handle generator function middleware
+
+### 2. Server Startup Command
+
+**Issue**: Running `node server` failed with "Cannot find module" error.
+
+**Solution**: Updated documentation to use `node server.js` instead of `node server`.
+
+### 3. Lodash Compatibility
+
+**Issue**: Lodash method compatibility issues in strategies route.
+
+**Solution**: Updated `web/routes/strategies.js` to use compatible lodash methods.
+
+### 4. WebSocket Configuration
+
+**Issue**: WebSocket connections were not properly handled in the server.
+
+**Solution**: Enabled WebSocket connection handling in `web/server.js`.
+
+### 5. Dynamic Configuration
+
+**Issue**: Hard-coded host/port configuration caused issues in different environments.
+
+**Solution**: Updated `web/vue/dist/UIconfig.js` to use dynamic host/port detection.
+
+## Installation Steps
+
+### Prerequisites
+
+- Node.js v22.16.0 or later
+- npm (comes with Node.js)
+
+### Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/viking76/gekko.git
+cd gekko
+
+# Install dependencies
+npm install
+
+# Start the web server
+cd web
+node server.js
+```
+
+### Manual Server Startup
+
+If you need to start the server manually:
+
+```bash
+cd gekko/web
+node server.js
+```
+
+The server will start on the configured host/port (default: localhost:3000).
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Cannot find module" error**
+   - Ensure you're using `node server.js` instead of `node server`
+   - Verify you're in the `gekko/web` directory
+
+2. **Koa middleware errors**
+   - The updated Koa v2.16.1 should resolve generator function issues
+   - If you see middleware errors, ensure koa-convert is installed
+
+3. **WebSocket connection issues**
+   - The web UI may show "Disconnected" initially - this is normal
+   - WebSocket connections are handled automatically by the server
+
+4. **API endpoint errors**
+   - Verify the server is running on the correct port
+   - Check that all dependencies are installed with `npm install`
+
+### Verification Steps
+
+Test that your installation is working:
+
+1. **Start the server**:
+   ```bash
+   cd gekko/web
+   node server.js
+   ```
+
+2. **Test API endpoints**:
+   ```bash
+   # Test server info
+   curl http://localhost:3000/api/info
+   
+   # Test strategies endpoint
+   curl http://localhost:3000/api/strategies
+   ```
+
+3. **Access web interface**:
+   Open http://localhost:3000 in your browser
+
+## Dependencies Updated
+
+The following dependencies were modified for Node.js v22 compatibility:
+
+- **koa**: 3.0.0 → 2.16.1
+- **koa-router**: 13.0.1 → 12.0.1
+- **koa-convert**: Added v2.0.0
+
+## Configuration Files Modified
+
+- `package.json` - Updated dependency versions
+- `web/server.js` - Added koa-convert wrappers, enabled WebSocket
+- `web/routes/strategies.js` - Fixed lodash compatibility
+- `web/vue/dist/UIconfig.js` - Dynamic host/port configuration
+
+## Additional Resources
+
+- [Node.js v22 Release Notes](https://nodejs.org/en/blog/release/v22.0.0)
+- [Koa v2 Documentation](https://koajs.com/)
+- [Gekko Server API Documentation](../internals/server_api.md)
+
+## Support
+
+If you encounter issues with Node.js v22 compatibility:
+
+1. Check this guide for common solutions
+2. Verify your Node.js version: `node --version`
+3. Ensure all dependencies are installed: `npm install`
+4. Visit the [Gekko Forum](https://forum.gekko.wizb.it/) for community support

--- a/docs/internals/server_api.md
+++ b/docs/internals/server_api.md
@@ -16,9 +16,11 @@ The server exposes two different APIs: A websocket API to push gekko updates and
 When you run `node gekko --ui` it will automatically start a server. You can also do this manually by running:
 
     cd gekko/web
-    node server
+    node server.js
 
-The server will now run on the host/port configured in `gekko/web/vue/public/UIConfig.js` (under api.host).
+**Note for Node.js v22+ users:** The server startup command has been updated to use `server.js` instead of `server` for better compatibility with modern Node.js versions.
+
+The server will now run on the host/port configured in `gekko/web/vue/dist/UIconfig.js` (under api.host).
 
 ## REST API
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Documentation update - Adds comprehensive Node.js v22 compatibility guide and fixes server startup documentation.

* **What is the current behavior?** (You can also link to an open issue here)

Users running Node.js v22+ encounter "Cannot find module '/home/user/gekko/server'" error when following the documentation that instructs to run `node server`. The server API documentation also references outdated file paths and lacks Node.js v22-specific guidance.

* **What is the new behavior (if this is a feature change)?**

- Added comprehensive Node.js v22 compatibility guide at `docs/installation/nodejs-v22-compatibility.md`
- Updated server API documentation to use correct `node server.js` command
- Fixed UIconfig.js path reference in documentation (updated to correct `web/vue/dist/UIconfig.js`)
- Added troubleshooting section for common Node.js v22 issues
- Updated main README with link to the new compatibility guide

* **Other information**:

This documentation update complements the recent Node.js v22 compatibility fixes by providing users with:

1. **Clear installation instructions** for Node.js v22+ users
2. **Troubleshooting guide** for common issues
3. **Updated server startup commands** that actually work
4. **Verification steps** to test the installation
5. **Reference to all dependency changes** made for compatibility

The guide covers all the technical changes made in the compatibility fixes:
- Koa framework downgrade (v3.0.0 → v2.16.1)
- koa-router downgrade (v13+ → v12.0.1) 
- koa-convert addition for generator function support
- Lodash compatibility fixes
- WebSocket configuration updates
- Dynamic host/port configuration

This should significantly improve the user experience for developers setting up Gekko with modern Node.js versions.