### PR TITLE
Fix Vue.js build: Update Copy Webpack Plugin configuration and add missing Babel plugin

### DIFF
--- a/web/vue/package-lock.json
+++ b/web/vue/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@vue/cli-plugin-babel": "^5.0.8",
         "@vue/cli-service": "^5.0.8",
+        "babel-plugin-transform-commonjs-es2015-modules": "^4.0.1",
         "copy-webpack-plugin": "^12.0.2",
         "pug": "^3.0.3",
         "pug-plain-loader": "^1.1.0",
@@ -3454,6 +3455,12 @@
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
+    },
+    "node_modules/babel-plugin-transform-commonjs-es2015-modules": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-commonjs-es2015-modules/-/babel-plugin-transform-commonjs-es2015-modules-4.0.1.tgz",
+      "integrity": "sha512-8h493ia3xNH5oQmckkQKl/Owtgk+wT6fCT0ZNAjos60YBNDu64UCAtd0mCWJg6N4lGvnmP++CIxWblxaJBdPwg==",
+      "dev": true
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",

--- a/web/vue/package.json
+++ b/web/vue/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@vue/cli-plugin-babel": "^5.0.8",
     "@vue/cli-service": "^5.0.8",
+    "babel-plugin-transform-commonjs-es2015-modules": "^4.0.1",
     "copy-webpack-plugin": "^12.0.2",
     "pug": "^3.0.3",
     "pug-plain-loader": "^1.1.0",

--- a/web/vue/vue.config.js
+++ b/web/vue/vue.config.js
@@ -3,17 +3,19 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = {
   configureWebpack: {
     plugins: [
-      new CopyWebpackPlugin([
-        {
-          from: '../baseUIconfig.js',
-          to: '../public/UIconfig.js'
-        },
-        {
-          from: '../baseUIconfig.js',
-          to: 'UIconfig.js'
-        },
-      ])
+      new CopyWebpackPlugin({
+        patterns: [
+          {
+            from: '../baseUIconfig.js',
+            to: '../public/UIconfig.js'
+          },
+          {
+            from: '../baseUIconfig.js',
+            to: 'UIconfig.js'
+          },
+        ]
+      })
     ]
   },
-  baseUrl: ''
+  publicPath: ''
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Bug fix

* **What is the current behavior?** 
The Vue.js build fails with a ValidationError from Copy Webpack Plugin due to using an outdated configuration format. The error occurs because the plugin expects a `patterns` object but receives an array with `to` properties directly. Additionally, a missing Babel plugin (`babel-plugin-transform-commonjs-es2015-modules`) causes the build to fail.

Error message:
```
ValidationError: Invalid options object. Copy Plugin has been initialized using an options object that does not match the API schema.
- options[0] has an unknown property 'to'. These properties are valid: object { patterns, options? }
```

* **What is the new behavior (if this is a feature change)?**
The Vue.js application now builds successfully without errors. The Copy Webpack Plugin configuration has been updated to use the modern API format compatible with version 12.0.2.

* **Other information**:
**Changes made:**
1. **Updated `vue.config.js`**: Changed Copy Webpack Plugin configuration from old array format to new `patterns` object format
2. **Added missing dependency**: Installed `babel-plugin-transform-commonjs-es2015-modules` in package.json
3. **Modernized configuration**: Changed deprecated `baseUrl` to `publicPath` in Vue configuration

**Files modified:**
- `web/vue/vue.config.js` - Updated webpack plugin configuration
- `web/vue/package.json` - Added missing Babel plugin dependency
- `web/vue/package-lock.json` - Updated with new dependency

**Testing:**
- ✅ Vue.js build completes successfully with `npm run build`
- ✅ All required files are copied correctly to the dist directory
- ✅ No breaking changes to existing functionality

This fix resolves the build issues and ensures the Vue.js frontend can be built properly for deployment.